### PR TITLE
分离参数由于有多个==导致被忽略，而请求失败的问题。

### DIFF
--- a/Cenarius/Core/Extension/NSString+Cenarius.m
+++ b/Cenarius/Core/Extension/NSString+Cenarius.m
@@ -54,10 +54,11 @@
         [scanner scanUpToCharactersFromSet:delimiterSet intoString:&pairString];
         [scanner scanCharactersFromSet:delimiterSet intoString:NULL];
         NSArray *kvPair = [pairString componentsSeparatedByString:@"="];
-        if (kvPair.count == 2) {
-            [pairs addItem:[[kvPair objectAtIndex:1] decodingStringUsingURLEscape]
-                         forKey:[[kvPair objectAtIndex:0] decodingStringUsingURLEscape]];
-        }
+        NSString *key = [kvPair firstObject];
+        NSRange range = [pairString rangeOfString:[key stringByAppendingString:@"="]];
+        NSString *value = [pairString substringFromIndex:range.length];
+        [pairs addItem:[key decodingStringUsingURLEscape]
+                forKey:[value decodingStringUsingURLEscape]];
     }
     
     return [pairs copy];


### PR DESCRIPTION
Url分离参数的时候，并不能用=判断分隔符，需要根据key+"=",然后根据长度提取出Value